### PR TITLE
Adding '--kubelet-preferred-address-types' flag to 'metrics-server'

### DIFF
--- a/Advanced Kubernetes/metrics-server/deploy/1.8+/metrics-server-deployment.yaml
+++ b/Advanced Kubernetes/metrics-server/deploy/1.8+/metrics-server-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         command:
           - /metrics-server
           - --kubelet-insecure-tls
+          - --kubelet-preferred-address-types=InternalIP
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
To resolve dns resolution issues in 'minikube v1.8.2' when starting 'metrics-server', added '--kubelet-preferred-address-types' to it.